### PR TITLE
remove explicit db library dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,10 @@
     "final-fs": "^1.6.0",
     "mkdirp": "~0.5.0",
     "moment": "~2.9.0",
-    "mongodb": "^1.4.30",
-    "mysql": "~2.5.4",
     "optimist": "~0.6.1",
     "parse-database-url": "~0.2.2",
-    "pg": "~4.3.0",
     "pkginfo": "~0.3.0",
     "semver": "~4.3.0",
-    "sqlite3": "~3.0.4",
     "bluebird": "~2.3.10"
   },
   "devDependencies": {


### PR DESCRIPTION
@wyefei I'm getting Hubot onto the most recent node, which needs a sqlite library upgrade, which this is preventing